### PR TITLE
Prefetch batches rather than individual datapoints

### DIFF
--- a/sts_playground/autoencoder/tf_lib.py
+++ b/sts_playground/autoencoder/tf_lib.py
@@ -294,8 +294,8 @@ def train(
 
     # prepare data
     with tf.device("cpu:0"):
-        train_ds = tf.data.Dataset.from_tensor_slices(train_set).prefetch(2)
-        valid_ds = tf.data.Dataset.from_tensor_slices(valid_set).prefetch(2)
+        train_ds = tf.data.Dataset.from_tensor_slices(train_set)
+        valid_ds = tf.data.Dataset.from_tensor_slices(valid_set)
 
     assert len(train_ds) == train_size
     del train_set, valid_set
@@ -304,6 +304,9 @@ def train(
     # train_ds = train_ds.shuffle(train_size, reshuffle_each_iteration=True)
     train_ds = train_ds.batch(batch_size, drop_remainder=True)
     valid_ds = valid_ds.batch(batch_size, drop_remainder=True)
+
+    train_ds = train_ds.prefetch(2)
+    valid_ds = valid_ds.prefetch(2)
 
     auto_encoder = make_auto_encoder(input_size, **network_config)
     optimizer = snt.optimizers.Adam(learning_rate)
@@ -337,8 +340,8 @@ def train(
         return loss, metrics
 
     # Save on memory by not compiling. This makes validation slower.
-    # if compile:
-    #   compute_loss = tf.function(compute_loss)
+    if compile:
+      compute_loss = tf.function(compute_loss)
 
     def train_step(batch) -> dict:
       with tf.GradientTape() as tape:


### PR DESCRIPTION
Prefetch after batching. Otherwise we're basically streaming 2 points data at a time through the buffer at batch access time.

Also turns on compilation for the validation function.